### PR TITLE
Fix simple.jl so that it runs on Julia 0.3 on OS X 10.9.3.

### DIFF
--- a/examples/simple.jl
+++ b/examples/simple.jl
@@ -4,13 +4,13 @@ import GLFW
 GLFW.Init()
 
 # Create a windowed mode window and its OpenGL context
-window = GLFW.CreateWindow(640, 480, "GLFW.jl")
+window = GLFW.CreateWindow(640, 480, "GLFW.jl", C_NULL, C_NULL)
 
 # Make the window's context current
 GLFW.MakeContextCurrent(window)
 
 # Loop until the user closes the window
-while !GLFW.WindowShouldClose(window)
+while GLFW.WindowShouldClose(window) == 0
 
 	# Render here
 


### PR DESCRIPTION
tl;dr: It looks like my local version of GLFW is different than current master in a way that prevents the example from running. I'm no longer sure what the right answer is, but it certainly isn't merging in this pull request. 

---
- Added two C_NULL arguments to GLFW.CreateWindow; there's only one method defined and it expects monitor::Ptr{None} and share::Ptr{None} arguments
- Check whether the return value of GLFW.WindowShouldClose is zero by == comparison rather than the boolean !GLFW.WindowShouldClose(window), which throws an error because WindowShouldClose returns an int and ! is not defined for integers.

I'm not sure whether the example _should_ work and there's something odd going on with my setup, or whether there's an actual issue, but in any case the two small edits in this pull request are required to get the example to run on my computer. 

I'll look into this more tomorrow if I get the chance, since the version of CreateWindow defined in glfw3.jl does have default values for the monitor and share arguments and yet I get an `ERROR: no method CreateWindow(Int64, Int64, ASCIIString)` when omitting them. It also looks like WindowShouldClose does indeed return a bool on the , so the negation operator should just work...

```
julia> Pkg.update()
INFO: Updating METADATA...
INFO: Updating GLFW...
INFO: Computing changes...
INFO: No packages to install, update or remove
```
