### PR TITLE
Fail gracefully when building library from source

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,6 +2,8 @@
 const version = VersionNumber(3, 0, 4)
 const glfw = "glfw-$version"
 
+# TODO: if the latest version is already installed, don't bother with any of this
+
 # download and compile the library from source
 @unix_only begin
 	mkpath("downloads")
@@ -13,16 +15,22 @@ const glfw = "glfw-$version"
 	mkpath("src")
 	run(`tar xzf $tarball -C src`)
 	map(mkpath, ("builds/$glfw", "usr$WORD_SIZE"))
-	cd("builds/$glfw") do
-		options = map(x -> "-D$(x[1])=$(x[2])", [
-			"BUILD_SHARED_LIBS"     => "ON",
-			"CMAKE_INSTALL_PREFIX"  => "../../usr$WORD_SIZE",
-			"GLFW_BUILD_DOCS"       => "OFF",
-			"GLFW_BUILD_EXAMPLES"   => "OFF",
-			"GLFW_BUILD_TESTS"      => "OFF"
-		])
-		run(`cmake $options ../../src/$glfw`)
-		run(`make install`)
+	try
+		info("Building GLFW $version library from source")
+		cd("builds/$glfw") do
+			options = map(x -> "-D$(x[1])=$(x[2])", [
+				"BUILD_SHARED_LIBS"     => "ON",
+				"CMAKE_INSTALL_PREFIX"  => "../../usr$WORD_SIZE",
+				"GLFW_BUILD_DOCS"       => "OFF",
+				"GLFW_BUILD_EXAMPLES"   => "OFF",
+				"GLFW_BUILD_TESTS"      => "OFF"
+			])
+			run(`cmake $options ../../src/$glfw`)
+			run(`make install`)
+		end
+	catch e
+		warn(e)
+		warn("Build failed, you may need to manually install the library (see http://www.glfw.org/download.html for more information)")
 	end
 end
 


### PR DESCRIPTION
Most users don't have the correct dependencies installed, so it's best
not to blow up when building from source doesn't work. The build error
is printed and the user is warned that they might need to manually
install the library.

Ideally, the build script should still be smart enough to install
everything auto-magically, but this will have to do for now.

Closes #14
Closes #18
Closes #21
