### PR TITLE
Remove info message

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -30,6 +30,5 @@ else
 	error("GLFW $VERSION is not supported")
 end
 
-#info("loaded GLFW $(GetVersionString()) from $lib")
 
 end

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -30,6 +30,6 @@ else
 	error("GLFW $VERSION is not supported")
 end
 
-info("loaded GLFW $(GetVersionString()) from $lib")
+#info("loaded GLFW $(GetVersionString()) from $lib")
 
 end


### PR DESCRIPTION
A library shouldn't print any infos per default, as one can't deactivate them.