### PR TITLE
Travis CI: Use CMake 2.8.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ julia:
   - nightly
 notifications:
   email: false
-before_install:
-  - sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y # Newer CMake
-  - sudo apt-get update -qq
-install:
-  - sudo apt-get install -y cmake libXxf86vm-dev  # GLFW dependencies
+sudo: false
+addons:
+  apt:
+    sources:
+    - debian-sid
+    packages:
+    - cmake
+    - libXxf86vm-dev
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ julia:
 notifications:
   email: false
 before_install:
-  - sudo add-apt-repository ppa:kalakris/cmake -y # Newer CMake
+  - sudo add-apt-repository ppa:smspillaz/cmake-2.8.12 -y # Newer CMake
   - sudo apt-get update -qq
 install:
   - sudo apt-get install -y cmake libXxf86vm-dev  # GLFW dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,10 @@ addons:
   apt:
     packages:
     - libxxf86vm-dev
-before_script:
+before_install:
   - "mkdir ~/cmake"
   - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz --strip-components=1 -C ~/cmake"
   - "export PATH=${HOME}/cmake/bin:${PATH}"
+before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ addons:
     - debian-sid
     packages:
     - cmake
-    - libxxf86vm-dev
 before_script:
   - "which cmake"
   - "cmake --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ addons:
     packages:
     - libxxf86vm-dev
 before_script:
-  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz"
-  - "export PATH=${PWD}/cmake-3.2.2-Linux-x86_64/bin:${PATH}"
-  - "echo $PATH"
-  - "which cmake"
-  - "cmake --version"
+  - "mkdir ~/cmake"
+  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz --strip-components=1 -C ~/cmake"
+  - "export PATH=${HOME}/cmake/bin:${PATH}"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ julia:
   - nightly
 notifications:
   email: false
-sudo: false
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,10 @@ notifications:
   email: false
 addons:
   apt:
-    sources:
-    - debian-sid
     packages:
-    - cmake
+    - libxxf86vm-dev
 before_script:
+  - "echo $PATH"
   - "which cmake"
   - "cmake --version"
   - "export DISPLAY=:99.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
     packages:
     - libxxf86vm-dev
 before_script:
-  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.sh | sh -s - --prefix=${HOME}/cmake"
-  - "export PATH=${HOME}/cmake:${PATH}"
+  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz"
+  - "export PATH=${PWD}/cmake-3.2.2-Linux-x86_64/bin:${PATH}"
   - "echo $PATH"
   - "which cmake"
   - "cmake --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
     packages:
     - libxxf86vm-dev
 before_script:
+  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.sh | sh -s - --prefix=${HOME}/cmake"
+  - "export PATH=${HOME}/cmake:${PATH}"
   - "echo $PATH"
   - "which cmake"
   - "cmake --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     - debian-sid
     packages:
     - cmake
-    - libXxf86vm-dev
+    - libxxf86vm-dev
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
   apt:
     packages:
     - libxxf86vm-dev
-before_install:
+install:
   - "mkdir ~/cmake"
   - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz --strip-components=1 -C ~/cmake"
   - "export PATH=${HOME}/cmake/bin:${PATH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ addons:
     - cmake
     - libxxf86vm-dev
 before_script:
+  - "which cmake"
+  - "cmake --version"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer


### PR DESCRIPTION
Travis CI is still running Ubuntu 12.04 which has an ancient version of CMake. This can probably go away once Travis is using 14.04.