### PR TITLE
Use new container system for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ julia:
   - nightly
 notifications:
   email: false
-before_install:
-  - sudo add-apt-repository ppa:kalakris/cmake -y # Newer CMake
-  - sudo apt-get update -qq
+addons:
+  apt:
+    packages:
+    - libxxf86vm-dev
 install:
-  - sudo apt-get install -y cmake libXxf86vm-dev  # GLFW dependencies
+  - "mkdir ~/cmake"
+  - "curl http://www.cmake.org/files/v3.2/cmake-3.2.2-Linux-x86_64.tar.gz | tar -xz --strip-components=1 -C ~/cmake"
+  - "export PATH=${HOME}/cmake/bin:${PATH}"
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start" # X virtual framebuffer


### PR DESCRIPTION
Since the CMake PPA is not whitelisted by Travis, install the newest
version from a cmake.org tarball instead.