### PR TITLE
Trigger recompilation if the library changes

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -6,6 +6,7 @@ const lib = Libdl.find_library(["glfw3", "libglfw3", "glfw", "libglfw"], [Pkg.di
 if isempty(lib)
 	error("could not find GLFW library")
 end
+@compat include_dependency(string(lib, ".", Libdl.dlext)) # Trigger recompilation if the library changes
 
 include("util.jl")
 


### PR DESCRIPTION
While precompilation has not been explicitly turned on (yet), including the library as a dependency should make it work smoothly for other modules that are precompiled and include GLFW.jl.