### PR TITLE
RFC: auto initialize GLFW in __init__ and deprecate Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Simple Window Example
 ```julia
 import GLFW
 
-# Initialize the library
-GLFW.Init()
-
 # Create a window and its OpenGL context
 window = GLFW.CreateWindow(640, 480, "GLFW.jl")
 

--- a/examples/callbacks.jl
+++ b/examples/callbacks.jl
@@ -1,6 +1,5 @@
 import GLFW
 
-GLFW.Init()
 window = GLFW.CreateWindow(800, 600, "GLFW Callback Test")
 GLFW.MakeContextCurrent(window)
 

--- a/examples/multiwindow.jl
+++ b/examples/multiwindow.jl
@@ -1,7 +1,5 @@
 import GLFW
 
-GLFW.Init()
-
 windows = []
 for i in 1:3
 	name = "Window $i"

--- a/examples/simple.jl
+++ b/examples/simple.jl
@@ -1,8 +1,5 @@
 import GLFW
 
-# Initialize the library
-GLFW.Init()
-
 # Create a windowed mode window and its OpenGL context
 window = GLFW.CreateWindow(640, 480, "GLFW.jl")
 

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -31,4 +31,8 @@ else
 	error("GLFW $VERSION is not supported")
 end
 
+function __init__()
+    GLFW.Init()
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-import GLFW
-
 travis = get(ENV, "TRAVIS", "") == "true"
 
 try
-	GLFW.Init()
+	# try...catch introduces a new scope, so we need to eval the import
+	# into the Main module scope.
+	eval(Main, :(import GLFW))
 catch e
 	if travis && contains(e.msg, "/dev/input: No such file or directory")
 		warn(e.msg)


### PR DESCRIPTION
From what I can tell the library initialization only needs to occur once. We can automatically do this in `__init__`, but it has the downside of conforming less to the C style API.