### PR TITLE
Fix some crashes

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -346,7 +346,7 @@ function CreateWindow(width::Integer, height::Integer, title::AbstractString, mo
 end
 
 DestroyWindow(window::Window) = ccall( (:glfwDestroyWindow, lib), Void, (WindowHandle,), window)
-WindowShouldClose(window::Window) = Bool(ccall( (:glfwWindowShouldClose, lib), Cint, (WindowHandle,), window))
+WindowShouldClose(window::Window) = ccall( (:glfwWindowShouldClose, lib), Cint, (WindowHandle,), window) != 0
 SetWindowShouldClose(window::Window, value::Bool) = ccall( (:glfwSetWindowShouldClose, lib), Void, (WindowHandle, Cint), window, value)
 SetWindowTitle(window::Window, title::AbstractString) = ccall( (:glfwSetWindowTitle, lib), Void, (WindowHandle, Cstring), window, title)
 

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -345,7 +345,7 @@ function CreateWindow(width::Integer, height::Integer, title::AbstractString, mo
 	window
 end
 
-DestroyWindow(window::Window) = ccall( (:glfwDestroyWindow, lib), Void, (WindowHandle,), window)
+DestroyWindow(window::Window) = (yield(); ccall( (:glfwDestroyWindow, lib), Void, (WindowHandle,), window))
 WindowShouldClose(window::Window) = ccall( (:glfwWindowShouldClose, lib), Cint, (WindowHandle,), window) != 0
 SetWindowShouldClose(window::Window, value::Bool) = ccall( (:glfwSetWindowShouldClose, lib), Void, (WindowHandle, Cint), window, value)
 SetWindowTitle(window::Window, title::AbstractString) = ccall( (:glfwSetWindowTitle, lib), Void, (WindowHandle, Cstring), window, title)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+ModernGL
+GeometryTypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ try
 	# try...catch introduces a new scope, so we need to eval the import
 	# into the Main module scope.
 	eval(Main, :(import GLFW))
+        include("windowclose.jl")
 catch e
 	if travis && contains(e.msg, "/dev/input: No such file or directory")
 		warn(e.msg)

--- a/test/windowclose.jl
+++ b/test/windowclose.jl
@@ -1,0 +1,12 @@
+import GLFW
+using Base.Test
+
+window = GLFW.CreateWindow(800, 600, "InexactError")
+@test !GLFW.WindowShouldClose(window)
+# If you call the julia function GLFW.SetWindowShouldClose(window,
+# truefalse), then only 0 or 1 can be passed. However, at least on
+# some platforms (Linux), clicking on the window's close icon can send
+# other values (like 189). Make sure such values don't cause trouble for
+# GLFW.WindowShouldClose.
+ccall( (:glfwSetWindowShouldClose, GLFW.lib), Void, (GLFW.WindowHandle, Cint), window, 189)
+@test GLFW.WindowShouldClose(window)

--- a/test/windowclose.jl
+++ b/test/windowclose.jl
@@ -10,3 +10,35 @@ window = GLFW.CreateWindow(800, 600, "InexactError")
 # GLFW.WindowShouldClose.
 ccall( (:glfwSetWindowShouldClose, GLFW.lib), Void, (GLFW.WindowHandle, Cint), window, 189)
 @test GLFW.WindowShouldClose(window)
+
+
+# Test for a segfault triggered by a scheduled task
+using ModernGL, GeometryTypes
+window = GLFW.CreateWindow(1024, 768, "Segfault")
+GLFW.MakeContextCurrent(window)
+
+vao = Ref(GLuint(0))
+glGenVertexArrays(1, vao)
+glBindVertexArray(vao[])
+
+vbo = Ref(GLuint(0))
+glGenBuffers(1, vbo)
+glBindBuffer(GL_ARRAY_BUFFER, vbo[])
+vertices = Point3f0[(-1,-1,0), (1,-1,0), (0, 1, 1)]
+glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW)
+
+glEnableVertexAttribArray(0)
+glBindBuffer(GL_ARRAY_BUFFER, vbo[])
+glVertexAttribPointer(0, length(vertices), GL_FLOAT, GL_FALSE, 0, C_NULL)
+
+function render()
+    glDrawArrays(GL_TRIANGLES, 0, length(vertices))
+    GLFW.SwapBuffers(window)
+    GLFW.PollEvents()
+end
+
+schedule(Task(render))
+
+GLFW.DestroyWindow(window)
+
+sleep(0.25)


### PR DESCRIPTION
This fixes two problems (observed on Linux w/ NVIDIA drivers):
  - `Bool(x)` produces an `InexactError` if `x != 0 && x != 1`
  - Addition of `yield()` before destroying the window allows any already-scheduled drawing operations to occur, preventing an error like:
```
X Error of failed request:  GLXBadDrawable
  Major opcode of failed request:  154 (GLX)
  Minor opcode of failed request:  11 (X_GLXSwapBuffers)
  Serial number of failed request:  171
  Current serial number in output stream:  172
```
