### PR TITLE
Fix #77 Update for Julia version v0.5, readall deprecation

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -40,7 +40,8 @@ end
 
 # download a pre-compiled binary (built by Bintray for Homebrew)
 @osx_only begin
-	const osx_version = convert(VersionNumber, readall(`sw_vers -productVersion`))
+	isdefined(:readstring) || (readstring = readall)
+	const osx_version = convert(VersionNumber, readstring(`sw_vers -productVersion`))
 	if osx_version >= v"10.11"
 		codename = "el_capitan"
 	elseif osx_version >= v"10.10"


### PR DESCRIPTION
Add a line to define readstring as readall if not defined, to make work on recent versions of v0.5