### PR TITLE
Fix `symbol` deprecation warning in Julia 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat 0.7.15

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,6 +4,8 @@ const glfw = "glfw-$version"
 
 # TODO: if the latest version is already installed, don't bother with any of this
 
+using Compat
+
 # download and compile the library from source
 @linux_only begin
 	mkpath("downloads")
@@ -40,7 +42,6 @@ end
 
 # download a pre-compiled binary (built by Bintray for Homebrew)
 @osx_only begin
-	isdefined(:readstring) || (readstring = readall)
 	const osx_version = convert(VersionNumber, readstring(`sw_vers -productVersion`))
 	if osx_version >= v"10.11"
 		codename = "el_capitan"

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module GLFW
 
+using Compat
+
 const lib = Libdl.find_library(["glfw3", "libglfw3", "glfw", "libglfw"], [Pkg.dir("GLFW/deps/usr$WORD_SIZE/lib")])
 if isempty(lib)
 	error("could not find GLFW library")

--- a/src/callback.jl
+++ b/src/callback.jl
@@ -6,8 +6,8 @@ macro callback(ex)
 	args = def.args[2:end]                             # (x::T1, y::T2, etc)
 	values = transform ? ex.args[2].args[2].args : map(argname, args)  # (x, y, etc) or whatever came after the ->
 
-	setter = symbol("Set", name)                       # SetFooCallback
-	libsetter = Expr(:quote, symbol("glfw", setter))   # glfwSetFooCallback
+	setter = Symbol("Set", name)                       # SetFooCallback
+	libsetter = Expr(:quote, Symbol("glfw", setter))   # glfwSetFooCallback
 	wrapper = gensym(string(name, "Wrapper"))          # FooCallbackWrapper
 
 	window_arg = filter(iswindow, args)                # :(window::Window)
@@ -56,7 +56,7 @@ end
 argname(ex) = ex.args[1]
 argtype(ex) = ex.args[2]
 iswindow(ex) = argtype(ex) == :Window
-win2handle(name::Symbol) = symbol(name, "_handle")
+win2handle(name::Symbol) = Symbol(name, "_handle")
 win2handle(ex) = iswindow(ex) ? :($(win2handle(argname(ex)))::WindowHandle) : ex
 undef(any...) = throw(UndefRefError())
 


### PR DESCRIPTION
The Compat package was re-added as a dependency so that `Symbol` will
work in Julia 0.4. A previous compatibility fix from commit 722785d was
also changed to leverage Compat.