### PR TITLE
Fix `WORD_SIZE` deprecation warning in Julia 0.5

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -4,7 +4,7 @@ module GLFW
 
 using Compat
 
-const lib = Libdl.find_library(["glfw3", "libglfw3", "glfw", "libglfw"], [Pkg.dir("GLFW/deps/usr$WORD_SIZE/lib")])
+const lib = Libdl.find_library(["glfw3", "libglfw3", "glfw", "libglfw"], [Pkg.dir("GLFW/deps/usr$(Sys.WORD_SIZE)/lib")])
 if isempty(lib)
 	error("could not find GLFW library")
 end


### PR DESCRIPTION
Closes #82