### PR TITLE
Replace `bytestring` with `String` for Julia 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.15
+Compat 0.7.20

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -3,6 +3,7 @@ __precompile__()
 module GLFW
 
 using Compat
+import Compat.String
 
 const lib = Libdl.find_library(["glfw3", "libglfw3", "glfw", "libglfw"], [Pkg.dir("GLFW/deps/usr$(Sys.WORD_SIZE)/lib")])
 if isempty(lib)

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -296,10 +296,10 @@ end
 # Initialization and version information
 Init() = Bool(ccall( (:glfwInit, lib), Cint, ())) || error("initialization failed")
 Terminate() = ccall( (:glfwTerminate, lib), Void, ())
-GetVersionString() = bytestring(ccall( (:glfwGetVersionString, lib), Cstring, ()))
+GetVersionString() = String(ccall( (:glfwGetVersionString, lib), Cstring, ()))
 
 # Error handling
-@callback Error(code::Cint, description::Cstring) -> (code, bytestring(description))
+@callback Error(code::Cint, description::Cstring) -> (code, String(description))
 
 # Monitor handling
 function GetMonitors()
@@ -322,7 +322,7 @@ function GetMonitorPhysicalSize(monitor::Monitor)
 	(width[], height[])
 end
 
-GetMonitorName(monitor::Monitor) = bytestring(ccall( (:glfwGetMonitorName, lib), Cstring, (Monitor,), monitor))
+GetMonitorName(monitor::Monitor) = String(ccall( (:glfwGetMonitorName, lib), Cstring, (Monitor,), monitor))
 @callback Monitor(monitor::Monitor, event::Cint)
 
 function GetVideoModes(monitor::Monitor)
@@ -426,7 +426,7 @@ SetCursor(window::Window, ::Void) = SetCursor(window, Cursor(C_NULL))
 @callback CursorPos(window::Window, xpos::Cdouble, ypos::Cdouble)
 @callback CursorEnter(window::Window, entered::Cint) -> (window, Bool(entered))
 @callback Scroll(window::Window, xoffset::Cdouble, yoffset::Cdouble)
-@callback Drop(window::Window, count::Cint, paths::Ptr{Ptr{Cchar}}) -> (window, map(bytestring, pointer_to_array(paths, count)))
+@callback Drop(window::Window, count::Cint, paths::Ptr{Ptr{Cchar}}) -> (window, map(String, pointer_to_array(paths, count)))
 JoystickPresent(joy::Integer) = Bool(ccall( (:glfwJoystickPresent, lib), Cint, (Cint,), joy))
 
 function GetJoystickAxes(joy::Integer)
@@ -441,7 +441,7 @@ function GetJoystickButtons(joy::Integer)
 	pointer_to_array(ptr, count[])
 end
 
-GetJoystickName(joy::Integer) = bytestring(ccall( (:glfwGetJoystickName, lib), Cstring, (Cint,), joy))
+GetJoystickName(joy::Integer) = String(ccall( (:glfwGetJoystickName, lib), Cstring, (Cint,), joy))
 
 # Context handling
 MakeContextCurrent(window::Window) = ccall( (:glfwMakeContextCurrent, lib), Void, (WindowHandle,), window)


### PR DESCRIPTION
Require a newer version of Compat.jl for Julia 0.4 compatibility.