### PR TITLE
Fix Homebrew installation

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -38,7 +38,7 @@ provides(SimpleBuild, cmake_build_steps, glfw)
 # get library through Homebrew, if available
 if Pkg.installed("Homebrew") != nothing
 	using Homebrew
-	provides(Homebrew.HB, "homebrew/versions/glfw3", glfw, os=:Darwin)
+	provides(Homebrew.HB, "glfw", glfw, os=:Darwin)
 end
 
 # download a pre-compiled binary (built by GLFW)


### PR DESCRIPTION
Homebrew moved the GLFW formula from their "versions" to "core" repo.

Problem discovered in JuliaGL/GLVisualize.jl#134.