### PR TITLE
treat errors as warnings

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -19,7 +19,7 @@ else
 end
 
 function __init__()
-	SetErrorCallback((code, description) -> error(description))
+	SetErrorCallback((code, description) -> warn(description))
 	GLFW.Init()
 	atexit(GLFW.Terminate)
 end


### PR DESCRIPTION
Seems like GLFW errors received via `ErrorCallback` should be treated more like warnings:
https://github.com/glfw/glfw/issues/958