### PR TITLE
Workaround Mac display name error

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -17,20 +17,20 @@ if libversion.major == 3
 else
 	error("GLFW $libversion is not supported")
 end
-function handle_error(code, description)
-	ex = GLFWError(code, description)
-	if ex.code == PLATFORM_ERROR && (
-			contains(ex.description, "Failed to get display service port iterator") ||
-			contains(ex.description, "Failed to retrieve display name") ||
-			contains(ex.description, "RandR gamma ramp support seems broken") ||
-			contains(ex.description, "RandR monitor support seems broken") ||
-			contains(ex.description, "Failed to watch for joystick connections in")
+function handle_error(int_code, description)
+	code = ErrorCode(int_code)
+	if code == PLATFORM_ERROR && (
+			contains(description, "Failed to get display service port iterator") ||
+			contains(description, "Failed to retrieve display name") ||
+			contains(description, "RandR gamma ramp support seems broken") ||
+			contains(description, "RandR monitor support seems broken") ||
+			contains(description, "Failed to watch for joystick connections in")
 		)
 		# Workaround: downgrade Mac display name error to warning
 		# https://github.com/glfw/glfw/issues/958
-		warn(ex)
+		warn("GLFW reports the following error: $description.\nThis can be ignored on a headless system.")
 	else
-		throw(ex)
+		throw(GLFWError(code, description))
 	end
 end
 

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -17,15 +17,8 @@ if libversion.major == 3
 else
 	error("GLFW $libversion is not supported")
 end
-function handle_error(code, description)
-    @show description
-    @show contains(description, "RandR gamma ramp support seems broken")
-    @show code == PLATFORM_ERROR && (
-		contains(description, "Failed to get display service port iterator") ||
-		contains(description, "Failed to retrieve display name") ||
-		contains(description, "RandR gamma ramp support seems broken") ||
-		contains(description, "Failed to watch for joystick connections in")
-	)
+function handle_error(code_int, description)
+    code = ErrorCode(code_int)
 	if code == PLATFORM_ERROR && (
 			contains(description, "Failed to get display service port iterator") ||
 			contains(description, "Failed to retrieve display name") ||

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -17,6 +17,7 @@ if libversion.major == 3
 else
 	error("GLFW $libversion is not supported")
 end
+
 function handle_error(int_code, description)
 	code = ErrorCode(int_code)
 	if code == PLATFORM_ERROR && (

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -18,11 +18,12 @@ else
 	error("GLFW $libversion is not supported")
 end
 function handle_error(code, description)
-    ex = GLFWError(code, description)
+	ex = GLFWError(code, description)
 	if ex.code == PLATFORM_ERROR && (
 			contains(ex.description, "Failed to get display service port iterator") ||
 			contains(ex.description, "Failed to retrieve display name") ||
 			contains(ex.description, "RandR gamma ramp support seems broken") ||
+			contains(ex.description, "RandR monitor support seems broken") ||
 			contains(ex.description, "Failed to watch for joystick connections in")
 		)
 		# Workaround: downgrade Mac display name error to warning

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -19,7 +19,7 @@ else
 end
 
 function __init__()
-	SetErrorCallback((code, description) -> error(description))
+	SetErrorCallback((code, description) -> throw(GLFWError(code, description)))
 	GLFW.Init()
 	atexit(GLFW.Terminate)
 end

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -18,6 +18,14 @@ else
 	error("GLFW $libversion is not supported")
 end
 function handle_error(code, description)
+    @show description
+    @show contains(description, "RandR gamma ramp support seems broken")
+    @show code == PLATFORM_ERROR && (
+		contains(description, "Failed to get display service port iterator") ||
+		contains(description, "Failed to retrieve display name") ||
+		contains(description, "RandR gamma ramp support seems broken") ||
+		contains(description, "Failed to watch for joystick connections in")
+	)
 	if code == PLATFORM_ERROR && (
 			contains(description, "Failed to get display service port iterator") ||
 			contains(description, "Failed to retrieve display name") ||

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -20,8 +20,8 @@ end
 function handle_error(code, description)
 	if code == PLATFORM_ERROR && (
 			contains(description, "Failed to get display service port iterator") ||
-			contains(description, "Failed to retrieve display name") ||
-			contains(description, "RandR gamma ramp support seems broken") ||
+			contains(description, "Failed to retrieve display name") ||
+			contains(description, "RandR gamma ramp support seems broken") ||
 			contains(description, "Failed to watch for joystick connections in")
 		)
 		# Workaround: downgrade Mac display name error to warning

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -17,19 +17,19 @@ if libversion.major == 3
 else
 	error("GLFW $libversion is not supported")
 end
-function handle_error(code_int, description)
-    code = ErrorCode(code_int)
-	if code == PLATFORM_ERROR && (
-			contains(description, "Failed to get display service port iterator") ||
-			contains(description, "Failed to retrieve display name") ||
-			contains(description, "RandR gamma ramp support seems broken") ||
-			contains(description, "Failed to watch for joystick connections in")
+function handle_error(code, description)
+    ex = GLFWError(code, description)
+	if ex.code == PLATFORM_ERROR && (
+			contains(ex.description, "Failed to get display service port iterator") ||
+			contains(ex.description, "Failed to retrieve display name") ||
+			contains(ex.description, "RandR gamma ramp support seems broken") ||
+			contains(ex.description, "Failed to watch for joystick connections in")
 		)
 		# Workaround: downgrade Mac display name error to warning
 		# https://github.com/glfw/glfw/issues/958
 		warn(ex)
 	else
-		throw(GLFWError(code, description))
+		throw(ex)
 	end
 end
 

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -17,9 +17,23 @@ if libversion.major == 3
 else
 	error("GLFW $libversion is not supported")
 end
+function handle_error(code, description)
+	if code == PLATFORM_ERROR && (
+			contains(description, "Failed to get display service port iterator") ||
+			contains(description, "Failed to retrieve display name") ||
+			contains(description, "RandR gamma ramp support seems broken") ||
+			contains(description, "Failed to watch for joystick connections in")
+		)
+		# Workaround: downgrade Mac display name error to warning
+		# https://github.com/glfw/glfw/issues/958
+		warn(ex)
+	else
+		throw(GLFWError(code, description))
+	end
+end
 
 function __init__()
-	SetErrorCallback((code, description) -> throw(GLFWError(code, description)))
+	SetErrorCallback(handle_error)
 	GLFW.Init()
 	atexit(GLFW.Terminate)
 end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -290,6 +290,12 @@ immutable VidMode
 	refreshrate::Cint   # The refresh rate, in Hz, of the video mode.
 end
 
+immutable GLFWError <: Exception
+	code::Cint
+	description::String
+end
+Base.showerror(io::IO, e::GLFWError) = print(io, "GLFWError: ", e.description)
+
 #************************************************************************
 # GLFW API functions
 #************************************************************************

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -177,13 +177,14 @@ const JOYSTICK_LAST          = JOYSTICK_16
 # Error codes
 const NOT_INITIALIZED        = 0x00010001  # GLFW has not been initialized.
 const NO_CURRENT_CONTEXT     = 0x00010002  # No context is current for this thread.
-const INVALID_ENUM           = 0x00010003  # One of the enum parameters for the function was given an invalid enum.
-const INVALID_VALUE          = 0x00010004  # One of the parameters for the function was given an invalid value.
+const INVALID_ENUM           = 0x00010003  # One of the arguments to the function was an invalid enum value.
+const INVALID_VALUE          = 0x00010004  # One of the arguments to the function was an invalid value.
 const OUT_OF_MEMORY          = 0x00010005  # A memory allocation failed.
-const API_UNAVAILABLE        = 0x00010006  # GLFW could not find support for the requested client API on the system.
-const VERSION_UNAVAILABLE    = 0x00010007  # The requested client API version is not available.
+const API_UNAVAILABLE        = 0x00010006  # GLFW could not find support for the requested API on the system.
+const VERSION_UNAVAILABLE    = 0x00010007  # The requested OpenGL or OpenGL ES version is not available.
 const PLATFORM_ERROR         = 0x00010008  # A platform-specific error occurred that does not match any of the more specific categories.
-const FORMAT_UNAVAILABLE     = 0x00010009  # The clipboard did not contain data in the requested format.
+const FORMAT_UNAVAILABLE     = 0x00010009  # The requested format is not supported or available.
+const NO_WINDOW_CONTEXT      = 0x0001000A  # The specified window does not have an OpenGL or OpenGL ES context.
 
 const FOCUSED                = 0x00020001
 const ICONIFIED              = 0x00020002

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -304,22 +304,7 @@ Base.showerror(io::IO, e::GLFWError) = print(io, "GLFWError ($(e.code)): ", e.de
 
 # Initialization and version information
 function Init()
-	try
-		return Bool(ccall( (:glfwInit, lib), Cint, ())) || error("initialization failed")
-	catch ex
-		if isa(ex, GLFWError) && ex.code == PLATFORM_ERROR && (
-				contains(ex.description, "Failed to get display service port iterator") ||
-				contains(ex.description, "Failed to retrieve display name") ||
-				contains(ex.description, "RandR gamma ramp support seems broken") ||
-				contains(ex.description, "Failed to watch for joystick connections in")
-			)
-			# Workaround: downgrade Mac display name error to warning
-			# https://github.com/glfw/glfw/issues/958
-			warn(ex)
-		else
-			rethrow()
-		end
-	end
+	return Bool(ccall( (:glfwInit, lib), Cint, ())) || error("initialization failed")
 end
 
 Terminate() = ccall( (:glfwTerminate, lib), Void, ())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,9 +13,9 @@ warning = String(readavailable(io_rd))
 close(io_rd)
 err_stream = redirect_stderr(ORIGINAL_IO)
 
-@test warning == """WARNING: GLFW reports the following error: X11: RandR gamma ramp support seems broken.
-This can be ignored on a headless system.
-"""
+# Contains, to be resilient against spliced in color commands
+@test contains(warning, """WARNING: GLFW reports the following error: X11: RandR gamma ramp support seems broken.
+This can be ignored on a headless system.""")
 @test_throws GLFW.GLFWError GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "test")
 
 if !travis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,22 @@
+using Base.Test
+
 travis = get(ENV, "TRAVIS", "") == "true"
 
 import GLFW
+
+# test errors
+ORIGINAL_IO = STDERR
+io_rd, io_wr = redirect_stderr()
+# should only warn
+GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "X11: RandR gamma ramp support seems broken")
+warning = String(readavailable(io_rd))
+close(io_rd)
+err_stream = redirect_stderr(ORIGINAL_IO)
+
+@test warning == """WARNING: GLFW reports the following error: X11: RandR gamma ramp support seems broken.
+This can be ignored on a headless system.
+"""
+@test_throws GLFW.GLFWError GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "test")
 
 if !travis
 	include("windowclose.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ close(io_rd)
 err_stream = redirect_stderr(ORIGINAL_IO)
 
 # Contains, to be resilient against spliced in color commands
-@test contains(warning, """WARNING: GLFW reports the following error: X11: RandR gamma ramp support seems broken.
+@test contains(warning, """GLFW reports the following error: X11: RandR gamma ramp support seems broken.
 This can be ignored on a headless system.""")
 @test_throws GLFW.GLFWError GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "test")
 


### PR DESCRIPTION
A new `GLFWError` type has been created so that the GLFW error code is retained and can be inspected on caught exceptions.

Closes #102