### PR TITLE
Treat non-fatal errors during glfwInit as warnings

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -18,28 +18,32 @@ else
 	error("GLFW $libversion is not supported")
 end
 
-function handle_error(int_code, description)
-	code = ErrorCode(int_code)
-	if code == PLATFORM_ERROR && (
-			contains(description, "Failed to get display service port iterator") ||
-			contains(description, "Failed to retrieve display name") ||
-			contains(description, "RandR gamma ramp support seems broken") ||
-			contains(description, "RandR monitor support seems broken") ||
-			contains(description, "Failed to watch for joystick connections in") ||
-			contains(description, "Failed to open joystick device directory")
-		)
-		# Workaround: downgrade Mac display name error to warning
-		# https://github.com/glfw/glfw/issues/958
-		warn("GLFW reports the following error: $description.\nThis can be ignored on a headless system.")
-	else
-		throw(GLFWError(code, description))
-	end
-end
+pusherror!(collection) = (code, description) -> push!(collection, GLFWError(code, description))
+throwerror(code, description) = throw(GLFWError(code, description))
 
 function __init__()
-	SetErrorCallback(handle_error)
-	GLFW.Init()
-	atexit(GLFW.Terminate)
+	initialized = false
+
+	# Save errors that occur during initialization
+	errors = Vector{Exception}()
+	SetErrorCallback(pusherror!(errors))
+
+	try
+		initialized = GLFW.Init()
+	catch err
+		push!(errors, err)
+	finally
+		SetErrorCallback(throwerror)
+	end
+
+	if initialized
+		atexit(GLFW.Terminate)
+		for err in errors
+			warn(err)  # Warn about any non-fatal errors that may have occurred during initialization
+		end
+	else
+		throw(errors)  # Throw fatal errors
+	end
 end
 
 end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -303,7 +303,7 @@ Base.showerror(io::IO, e::GLFWError) = print(io, "GLFWError ($(e.code)): ", e.de
 #************************************************************************
 
 # Initialization and version information
-Init() = Bool(ccall( (:glfwInit, lib), Cint, ())) || error("initialization failed")
+Init() = Bool(ccall( (:glfwInit, lib), Cint, ())) || error("glfwInit failed")
 Terminate() = ccall( (:glfwTerminate, lib), Void, ())
 GetVersionString() = unsafe_string(ccall( (:glfwGetVersionString, lib), Cstring, ()))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,6 @@
-using Base.Test
-
 travis = get(ENV, "TRAVIS", "") == "true"
 
 import GLFW
-
-# test errors
-ORIGINAL_IO = STDERR
-io_rd, io_wr = redirect_stderr()
-# should only warn
-GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "X11: RandR gamma ramp support seems broken")
-warning = String(readavailable(io_rd))
-close(io_rd)
-err_stream = redirect_stderr(ORIGINAL_IO)
-
-# Contains, to be resilient against spliced in color commands
-@test contains(warning, """GLFW reports the following error: X11: RandR gamma ramp support seems broken.
-This can be ignored on a headless system.""")
-@test_throws GLFW.GLFWError GLFW.handle_error(Cint(GLFW.PLATFORM_ERROR), "test")
 
 if !travis
 	include("windowclose.jl")


### PR DESCRIPTION
Detect fatal vs. non-fatal initialization errors

Errors are considered non-fatal if `glfwInit` completes successfully.
They will be reported as warnings rather than thrown.

This removes the need to maintain a whitelist of non-fatal errors.