### PR TITLE
changes for static compilation

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -18,28 +18,8 @@ else
 	error("GLFW $libversion is not supported")
 end
 
-<<<<<<< HEAD
-function handle_error(int_code, description)
-	code = ErrorCode(int_code)
-	if code == PLATFORM_ERROR && (
-			contains(description, "Failed to get display service port iterator") ||
-			contains(description, "Failed to retrieve display name") ||
-			contains(description, "RandR gamma ramp support seems broken") ||
-			contains(description, "RandR monitor support seems broken") ||
-			contains(description, "Failed to watch for joystick connections in") ||
-			contains(description, "Failed to open joystick device directory")
-		)
-		# Workaround: downgrade Mac display name error to warning
-		# https://github.com/glfw/glfw/issues/958
-		#warn("GLFW reports the following error: $description.\nThis can be ignored on a headless system.")
-	else
-		throw(GLFWError(code, description))
-	end
-end
-=======
 pusherror!(collection) = (code, description) -> push!(collection, GLFWError(code, description))
 throwerror(code, description) = throw(GLFWError(code, description))
->>>>>>> master
 
 function __init__()
 	initialized = false

--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -30,7 +30,7 @@ function handle_error(int_code, description)
 		)
 		# Workaround: downgrade Mac display name error to warning
 		# https://github.com/glfw/glfw/issues/958
-		warn("GLFW reports the following error: $description.\nThis can be ignored on a headless system.")
+		#warn("GLFW reports the following error: $description.\nThis can be ignored on a headless system.")
 	else
 		throw(GLFWError(code, description))
 	end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -273,7 +273,7 @@ type Window
 	handle::WindowHandle
 	callbacks::Vector{Function}
 end
-Window(handle::WindowHandle) = Window(handle, Vector{Function}(_window_callbacks_len))
+Window(handle::WindowHandle) = Window(handle, Vector{Function}(_window_callbacks_len[]))
 import Base.==; ==(x::Window, y::Window) = (x.handle == y.handle)
 Base.cconvert(::Type{WindowHandle}, window::Window) = window.handle
 Base.cconvert(::Type{Window}, handle::WindowHandle) = ccall( (:glfwGetWindowUserPointer, lib), Ref{Window}, (WindowHandle,), handle)


### PR DESCRIPTION
* removes non constant global
* removes non predictable name of callback wrapper for snoop compile (since we control the namespace, this should be safe)
* I've commented out the warning for now, I need to figure out a better way for this. But recently I started getting warnings, that my joystick connection can't be watched because the hard drive is full (it isn't?) Printing in the `__init__` might not be safe for static compilation. I still need to figure out why this happens, and if it's actually a problem - it's a bit hard to debug since I only get the warning from time to time and compiling different variations always takes a couple of minutes.