### PR TITLE
Replace `Nullable{T}` with `Union{T, Nothing}`

### DIFF
--- a/examples/callbacks.jl
+++ b/examples/callbacks.jl
@@ -19,8 +19,12 @@ actiontext = Dict(
 	GLFW.REPEAT  => "repeats"
 )
 GLFW.SetKeyCallback(window, (_, key, scancode, action, mods) -> begin
-	name = get(GLFW.GetKeyName(key, scancode), "$key")
-	println("key $name ", actiontext[action])
+	name = GLFW.GetKeyName(key, scancode)
+	if name == nothing
+		println("scancode $scancode ", actiontext[action])
+	else
+		println("key $name ", actiontext[action])
+	end
 end)
 
 GLFW.SetCharModsCallback(window, (_, c, mods) -> println("char: $c, mods: $mods"))

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -504,12 +504,10 @@ end
 SetInputMode(window::Window, mode::Integer, value::Integer) = ccall( (:glfwSetInputMode, lib), Cvoid, (WindowHandle, Cint, Cint), window, mode, value)
 GetKey(window::Window, key::Integer) = Bool(ccall( (:glfwGetKey, lib), Cint, (WindowHandle, Cint), window, key))
 
-function GetKeyName(key::Integer, scancode::Integer)
+function GetKeyName(key::Integer, scancode::Integer=0)
 	ptr = ccall( (:glfwGetKeyName, lib), Cstring, (Cint, Cint), key, scancode)
-	if ptr == C_NULL
-		Nullable{String}()
-	else
-		Nullable(unsafe_string(ptr))
+	if ptr != C_NULL
+		unsafe_string(ptr)
 	end
 end
 


### PR DESCRIPTION
`Nullable` is no longer used in Julia 0.7 nightly builds.

This is a breaking change from a semantic versioning perspective.