### PR TITLE
Add Vulkan support

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -15,6 +15,7 @@ const libversion = GetVersion()
 if libversion.major == 3
 	include("callback.jl")
 	include("glfw3.jl")
+	include("vulkan.jl")
 	if isdefined(Base, :getproperty) && isdefined(Base, :setproperty!)
 		# Julia 0.7 supports property overloading
 		# TODO for Julia upgrade: remove feature guard

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -228,6 +228,7 @@ const CONTEXT_RELEASE_BEHAVIOR = 0x00022009
 
 const OPENGL_API             = 0x00030001
 const OPENGL_ES_API          = 0x00030002
+const NO_API                 =          0
 
 const NO_ROBUSTNESS          =          0
 const NO_RESET_NOTIFICATION  = 0x00031001

--- a/src/vulkan.jl
+++ b/src/vulkan.jl
@@ -1,0 +1,53 @@
+# define Vulkan types locally, so we don't need to add VulkanCore.jl as dependency
+const VkResult = Cuint
+const VkInstance = Ptr{Void}
+const VkSurfaceKHR = Ptr{Void}
+const VkPhysicalDevice = Ptr{Void}
+
+struct VkAllocationCallbacks
+    pUserData::Ptr{Void}
+    pfnAllocation::Ptr{Void}
+    pfnReallocation::Ptr{Void}
+    pfnFree::Ptr{Void}
+    pfnInternalAllocation::Ptr{Void}
+    pfnInternalFree::Ptr{Void}
+end
+
+"""
+    VulkanSupported()
+Return whether the Vulkan loader has been found.
+"""
+VulkanSupported() = Bool(ccall((:glfwVulkanSupported, lib), Cint, ()))
+
+"""
+    GetRequiredInstanceExtensions()
+Return a vector of names of Vulkan instance extensions.
+"""
+function GetRequiredInstanceExtensions()
+    count = Ref{Cuint}(0)
+    ptr = ccall((:glfwGetRequiredInstanceExtensions, lib), Ptr{Ptr{Cchar}}, (Ref{Cuint},), count)
+    return unsafe_string.(unsafe_wrap(Array, ptr, count[]))
+end
+
+"""
+    CreateWindowSurface(instance, window, allocator=C_NULL)
+Create a Vulkan surface for the specified window.
+"""
+function CreateWindowSurface(instance, window::Window, allocator=C_NULL)
+    surface = Ref{VkSurfaceKHR}(C_NULL)
+    ccall((:glfwCreateWindowSurface, lib), VkResult, (VkInstance, WindowHandle, Ptr{VkAllocationCallbacks}, Ref{VkSurfaceKHR}), instance, window, allocator, surface)
+    return surface[]
+end
+
+"""
+    GetInstanceProcAddress(instance, procname) -> funcptr
+Return the address of the specified Vulkan core or extension function for the specified instance.
+`funcptr` can be used directly as the first argument of `ccall`: ccall(funcptr, ...).
+"""
+GetInstanceProcAddress(instance, procname) = ccall((:glfwGetInstanceProcAddress, lib), Ptr{Void}, (VkInstance, Cstring), instance, procname)
+
+"""
+    GetPhysicalDevicePresentationSupport(instance, device, queuefamily)
+Return whether the specified queue family of the specified physical device supports presentation to the platform GLFW was built for.
+"""
+GetPhysicalDevicePresentationSupport(instance, device, queuefamily) = Bool(ccall((:glfwGetPhysicalDevicePresentationSupport, lib), Cint, (VkInstance, VkPhysicalDevice, Cuint), instance, device, queuefamily))


### PR DESCRIPTION
This PR adds basic Vulkan support for GLFW.jl, but it'll add [VulkanCore.jl](https://github.com/JuliaGPU/VulkanCore.jl) as an additional dependency. I don't know whether it's a good idea to support Vulkan in this way, please give it a review at your convenience.