### PR TITLE
Sd/compat

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -43,13 +43,13 @@ end
 provides(SimpleBuild, cmake_build_steps, glfw)
 
 # get library through Homebrew, if available
-if Sys.isapple()
+if isapple()
 	using Homebrew
 	provides(Homebrew.HB, "glfw", glfw, os=:Darwin)
 end
 
 # download a pre-compiled binary (built by GLFW)
-if Sys.iswindows()
+if iswindows()
 	archive = "glfw-$version.bin.WIN$(Sys.WORD_SIZE)"
 	libpath = joinpath(archive, "lib-mingw-w64")
 	uri = URI("https://github.com/glfw/glfw/releases/download/$version/$archive.zip")

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -8,10 +8,14 @@ if !isdefined(Base, :Nothing)
 	const Nothing = Void
 end
 
-if !isdefined(Sys, :isapple)
-	Sys.eval(:(isapple = is_apple))
+const isapple = if !isdefined(Sys, :isapple)
+	is_apple
+else
+	Sys.isapple
 end
 
-if !isdefined(Sys, :iswindows)
-	Sys.eval(:(iswindows = is_windows))
+const iswindows = if !isdefined(Sys, :iswindows)
+	is_windows
+else
+	Sys.iswindows
 end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -275,12 +275,13 @@ Base.show(io::IO, m::Monitor) = write(io, "Monitor($(m.handle == C_NULL ? m.hand
 struct Window
 	handle::Ptr{Cvoid}
 end
+
 #Came from GLWindow.jl/screen.jl
 """
 Function to create a pure GLFW OpenGL window
 """
 function Window(
-		name = "GLWindow";
+		;name = "GLWindow",
 		resolution = standard_screen_resolution(),
 		debugging = false,
 		major = 3,
@@ -301,7 +302,7 @@ function Window(
 		WindowHint(wh[1], wh[2])
 	end
 
-	@static if is_apple()
+	@static if isapple()
 		if debugging
 			warn("OpenGL debug message callback not available on osx")
 			debugging = false

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -291,7 +291,8 @@ function Window(
 		visible = true,
 		focus = false,
 		fullscreen = false,
-		monitor = nothing
+		monitor = nothing,
+		share = Window(C_NULL)
 	)
 	WindowHint(VISIBLE, visible)
 	WindowHint(FOCUSED, focus)
@@ -321,7 +322,7 @@ function Window(
 		error("Monitor needs to be nothing, int, or GLFW.Monitor. Found: $monitor")
 	end
 
-	window = CreateWindow(resolution..., String(name))
+	window = CreateWindow(resolution..., String(name), Monitor(C_NULL), share)
 
 	if fullscreen
 		SetKeyCallback(window, (_1, button, _2, _3, _4) -> begin


### PR DESCRIPTION
* introduce `share` kw_arg to share an OpenGL context with the `Window` constructor
* moved name into kw_args for `Window` constructor to avoid printing a warning
* removed unnecessary `eval` that broke precompilation