### PR TITLE
make window mutable

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -272,7 +272,7 @@ struct Monitor
 end
 Base.show(io::IO, m::Monitor) = write(io, "Monitor($(m.handle == C_NULL ? m.handle : GetMonitorName(m)))")
 
-struct Window
+mutable struct Window
 	handle::Ptr{Cvoid}
 end
 


### PR DESCRIPTION
After debugging some issue, I figured it came down to me not correctly identifying closed/destroyed contexts.
It is basically impossible to detect them if we have the window immutable, since OpenGL is free to reuse context pointers, so you can't possibly tell by just the pointer if it's a valid context.
So I'd need to wrap GLFW.Window into MyMutableWindow, and then reimplement all GLFW functions on it, if I want to propperly check for valid contexts in all my types I pass the window to.
