### PR TITLE
Added wrappers, improved joysticks, and reordered

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.7
 BinDeps
 @!windows CMakeWrapper
-@osx Homebrew 0.6.5
+@osx Homebrew 0.7.0

--- a/examples/callbacks.jl
+++ b/examples/callbacks.jl
@@ -1,5 +1,9 @@
 using GLFW
 
+# Device callbacks
+GLFW.SetJoystickCallback((joystick, event) -> println("$joystick $event"))
+GLFW.SetMonitorCallback((monitor, event) -> println("$monitor $event"))
+
 window = GLFW.CreateWindow(640, 480, "GLFW Callback Test")
 GLFW.MakeContextCurrent(window)
 

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -491,14 +491,11 @@ function GetWindowSize(window::Window)
 	(width=width[], height=height[])
 end
 
-SetWindowSizeLimits(window, minwidth, minheight, maxwidth, maxheight) =
-	ccall((:glfwSetWindowSizeLimits, lib),
-		Cvoid, (Window, Cint, Cint, Cint, Cint),
-		window, minwidth, minheight, maxwidth, maxheight)
-
+SetWindowSizeLimits(window, minwidth, minheight, maxwidth, maxheight) = ccall((:glfwSetWindowSizeLimits, lib),
+	Cvoid, (Window, Cint, Cint, Cint, Cint), window, minwidth, minheight, maxwidth, maxheight)
 SetWindowAspectRatio(window, numer, denom) = ccall((:glfwSetWindowAspectRatio, lib),
 	Cvoid, (Window, Cint, Cint), window, numer, denom)
-
+SetWindowAspectRatio(window, r::Rational) = SetWindowAspectRatio(window, r.num, r.den)
 SetWindowSize(window::Window, width::Integer, height::Integer) = ccall((:glfwSetWindowSize, lib), Cvoid, (Window, Cint, Cint), window, width, height)
 
 function GetFramebufferSize(window::Window)

--- a/src/vulkan.jl
+++ b/src/vulkan.jl
@@ -30,16 +30,6 @@ function GetRequiredInstanceExtensions()
 end
 
 """
-    CreateWindowSurface(instance, window, allocator=C_NULL)
-Create a Vulkan surface for the specified window.
-"""
-function CreateWindowSurface(instance, window, allocator=C_NULL)
-    surface = Ref{VkSurfaceKHR}(C_NULL)
-    ccall((:glfwCreateWindowSurface, lib), VkResult, (VkInstance, Window, Ptr{VkAllocationCallbacks}, Ref{VkSurfaceKHR}), instance, window, allocator, surface)
-    return surface[]
-end
-
-"""
     GetInstanceProcAddress(instance, procname) -> funcptr
 Return the address of the specified Vulkan core or extension function for the specified instance.
 `funcptr` can be used directly as the first argument of `ccall`: ccall(funcptr, ...).
@@ -51,3 +41,13 @@ GetInstanceProcAddress(instance, procname) = ccall((:glfwGetInstanceProcAddress,
 Return whether the specified queue family of the specified physical device supports presentation to the platform GLFW was built for.
 """
 GetPhysicalDevicePresentationSupport(instance, device, queuefamily) = Bool(ccall((:glfwGetPhysicalDevicePresentationSupport, lib), Cint, (VkInstance, VkPhysicalDevice, Cuint), instance, device, queuefamily))
+
+"""
+    CreateWindowSurface(instance, window, allocator=C_NULL)
+Create a Vulkan surface for the specified window.
+"""
+function CreateWindowSurface(instance, window, allocator=C_NULL)
+    surface = Ref{VkSurfaceKHR}(C_NULL)
+    ccall((:glfwCreateWindowSurface, lib), VkResult, (VkInstance, Window, Ptr{VkAllocationCallbacks}, Ref{VkSurfaceKHR}), instance, window, allocator, surface)
+    return surface[]
+end


### PR DESCRIPTION
Added:
- `MaximizeWindow`
- `SetJoystickCallback`
- `SetWindowSizeLimits`
- `SetWindowAspectRatio`

Changed:
- Grouped `[DIS]CONNECTED` into `DeviceConfigEvent` enum
- Grouped `JOYSTICK_*` into `Joystick` enum
- Joystick functions return nothing for `NULL` pointers

Reordered to match glfw.h:
- `GLFWImage` type
- `GetKey`
- `SetWindowIcon`
- `SetWindowMonitor`
- Vulkan `CreateWindowSurface`