### PR TITLE
Fix safety of icon lib calls

### DIFF
--- a/src/GLFW.jl
+++ b/src/GLFW.jl
@@ -1,6 +1,6 @@
 module GLFW
 
-const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+const depsjl_path = joinpath(@__DIR__, "..", "deps", "deps.jl")
 if !isfile(depsjl_path)
     error("GLFW not installed properly, run Pkg.build(\"GLFW\"), restart Julia and try again")
 end


### PR DESCRIPTION
Previously it was possible to have exceptional cases that could cause segfaults 
( exceptional cases, which I was not able to trigger, but nevertheless good to fix) 

We can tag after this is merged.

