### PR TITLE
wrap callback call in try catch

### DIFF
--- a/src/callback.jl
+++ b/src/callback.jl
@@ -40,8 +40,14 @@ function callbackcode(
 
 	quote
 		# Callback wrapper that can be passed to `cfunction`
-		$wrapper($(callback_params...)) = ($callback_ref($(callback_args...)); return nothing)
-		
+		function $wrapper($(callback_params...))
+			try
+				($callback_ref($(callback_args...)); return nothing)
+			catch e
+				@warn("Errors not supported in C callback. Found: $e")
+			end
+		end
+
 		# Set the callback function
 		function $setter($(setter_param_names...), callback::Function)
 			old_callback = $callback_ref


### PR DESCRIPTION
I remember reading, that errors in c callbacks yield undefined behavior! Since I ran into some undefined behavior with GLFW, I figured that it might be this.
I'm not 100% if that's actually true, so we shouldn't use this try catch if it's false. We should probably also try to give some more information & backtrace.

Sorry to ping you directly, but @yuyichao, you're probably the only one who would know the answer to this question with certainty!