### PR TITLE
Add ARM CI via drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,61 @@
+kind: pipeline
+name: linux-arm-1.0
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-arm-1.2
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1.2
+  commands:
+      - uname -a
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.0
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.0
+  commands:
+      - uname -a
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+
+---
+
+kind: pipeline
+name: linux-aarch64-1.2
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: build
+  image: julia:1.2
+  commands:
+      - uname -a
+      - julia --project=. -e 'using Pkg; Pkg.build(); Pkg.test(coverage=true)'

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+
 kind: pipeline
 name: linux-arm-1.0
 


### PR DESCRIPTION
We're seeing build failures on the Nvidia Jetson Nano (ARMv8) so I've added  drone for ARM testing

```
  Building GLFW ────────────→ `~/.julia/packages/GLFW/e257h/deps/build.log`
┌ Error: Error building `GLFW`: 
│ -- The C compiler identification is GNU 7.4.0
│ -- Check for working C compiler: /usr/bin/cc
│ -- Check for working C compiler: /usr/bin/cc -- works
│ -- Detecting C compiler ABI info
│ -- Detecting C compiler ABI info - done
│ -- Detecting C compile features
│ -- Detecting C compile features - done
│ -- Looking for pthread.h
│ -- Looking for pthread.h - found
│ -- Looking for pthread_create
│ -- Looking for pthread_create - not found
│ -- Looking for pthread_create in pthreads
│ -- Looking for pthread_create in pthreads - not found
│ -- Looking for pthread_create in pthread
│ -- Looking for pthread_create in pthread - found
│ -- Found Threads: TRUE  
│ -- Using X11 for window creation
│ -- Looking for XOpenDisplay in /usr/lib/aarch64-linux-gnu/libX11.so;/usr/lib/aarch64-linux-gnu/libXext.so
│ -- Looking for XOpenDisplay in /usr/lib/aarch64-linux-gnu/libX11.so;/usr/lib/aarch64-linux-gnu/libXext.so - found
│ -- Looking for gethostbyname
│ -- Looking for gethostbyname - found
│ -- Looking for connect
│ -- Looking for connect - found
│ -- Looking for remove
│ -- Looking for remove - found
│ -- Looking for shmat
│ -- Looking for shmat - found
│ -- Looking for IceConnectionNumber in ICE
│ -- Looking for IceConnectionNumber in ICE - found
│ -- Found X11: /usr/lib/aarch64-linux-gnu/libX11.so
│ CMake Error at CMakeLists.txt:220 (message):
│   The Xinerama headers were not found
│ 
│ 
│ -- Configuring incomplete, errors occurred!
│ See also "/home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src/build/CMakeFiles/CMakeOutput.log".
│ See also "/home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src/build/CMakeFiles/CMakeError.log".
│ [ Info: Downloading https://github.com/glfw/glfw/archive/3.3.tar.gz to /home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src.tar.gz...
│ [ Info: Unpacking /home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src.tar.gz into /home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src
│ ┌ Warning: 
│ │ ================================================================
│ │ ================================================================
│ │ === Building GLFW has failed. Most common problem is,        ===
│ │ === that you don't have x-org installed.                     ===
│ │ === You can install it via: `sudo apt-get install xorg-dev`  ===
│ │ ================================================================
│ │ ================================================================
│ └ @ Main ~/.julia/packages/GLFW/e257h/deps/build.jl:56
│ ERROR: LoadError: failed process: Process(`/home/jacob/.julia/packages/CMake/nSK2r/deps/usr/bin/cmake -DBUILD_SHARED_LIBS=on -DGLFW_BUILD_DOCS=OFF -DGLFW_BUILD_EXAMPLES=OFF -DGLFW_BUILD_TESTS=OFF ..`, ProcessExited(1)) [1]
│ 
│ Stacktrace:
│  [1] pipeline_error at ./process.jl:525 [inlined]
│  [2] #run#569(::Bool, ::typeof(run), ::Cmd) at ./process.jl:440
│  [3] run at ./process.jl:438 [inlined]
│  [4] (::var"##9#10")() at /home/jacob/.julia/packages/GLFW/e257h/deps/build.jl:51
│  [5] cd(::var"##9#10", ::String) at ./file.jl:104
│  [6] top-level scope at /home/jacob/.julia/packages/GLFW/e257h/deps/build.jl:43
│  [7] include at ./boot.jl:328 [inlined]
│  [8] include_relative(::Module, ::String) at ./loading.jl:1105
│  [9] include(::Module, ::String) at ./Base.jl:31
│  [10] include(::String) at ./client.jl:432
│  [11] top-level scope at none:5
│ in expression starting at /home/jacob/.julia/packages/GLFW/e257h/deps/build.jl:21
│ [17:53:16] --2019-09-04 17:53:16--  https://github.com/glfw/glfw/archive/3.3.tar.gz
│ [17:53:16] Resolving github.com (github.com)... 192.30.253.112
│ [17:53:16] Connecting to github.com (github.com)|192.30.253.112|:443... connected.
│ [17:53:20] HTTP request sent, awaiting response... 302 Found
│ [17:53:20] Location: https://codeload.github.com/glfw/glfw/tar.gz/3.3 [following]
│ [17:53:20] --2019-09-04 17:53:20--  https://codeload.github.com/glfw/glfw/tar.gz/3.3
│ [17:53:20] Resolving codeload.github.com (codeload.github.com)... 140.82.114.10
│ [17:53:20] Connecting to codeload.github.com (codeload.github.com)|140.82.114.10|:443... connected.
│ [17:53:20] HTTP request sent, awaiting response... 200 OK
│ [17:53:20] Length: unspecified [application/x-gzip]
│ [17:53:20] Saving to: ‘/home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src.tar.gz’
│ [17:53:20] 
│ [17:53:20]      0K .......... .......... .......... .......... .......... 1.92M
│ [17:53:20]     50K .......... .......... .......... .......... .......... 6.93M
│ [17:53:20]    100K .......... .......... .......... .......... .......... 4.95M
│ [17:53:20]    150K .......... .......... .......... .......... .......... 12.0M
│ [17:53:20]    200K .......... .......... .......... .......... .......... 9.73M
│ [17:53:20]    250K .......... .......... .......... .......... .......... 27.2M
│ [17:53:20]    300K .......... .......... .......... .......... .......... 10.0M
│ [17:53:20]    350K .......... .......... .......... .......... .......... 4.22M
│ [17:53:20]    400K .......... .......... .......... .......... .......... 8.43M
│ [17:53:20]    450K .......... .......... .......... .......... .......... 4.36M
│ [17:53:20]    500K .......... .......... .......... .......... .......... 6.81M
│ [17:53:20]    550K .......... .......... .......... .......... .......... 5.65M
│ [17:53:20]    600K .......... .......... .......... .......... .......... 6.09M
│ [17:53:20]    650K .......... .......... .......... .......... .......... 8.43M
│ [17:53:20]    700K .......... .......... .......... ..........            14.0M=0.1s
│ [17:53:20] 
│ [17:53:20] 2019-09-04 17:53:20 (6.07 MB/s) - ‘/home/jacob/.julia/packages/GLFW/e257h/deps/usr/downloads/src.tar.gz’ saved [758352]
│ [17:53:20] 
└ @ Pkg.Operations /buildworker/worker/package_linuxaarch64/build/usr/share/julia/stdlib/v1.3/Pkg/src/backwards_compatible_isolation.jl:649
  ```

cc. @jacobdavis608