### PR TITLE
CI updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,12 +6,12 @@ task:
     matrix:
       - JULIA_VERSION: 1.3
       - JULIA_VERSION: nightly
-  allow_failures: $JULIA_VERSION == "nightly"
+  allow_failures: true # $JULIA_VERSION == "nightly"
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:
     - cirrusjl build
   test_script:
-    - xvfb-run cirrusjl test
+    - cirrusjl test
   coverage_script:
     - cirrusjl coverage codecov coveralls

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,6 @@ task:
   build_script:
     - cirrusjl build
   test_script:
-    - cirrusjl test
+    - xvfb-run cirrusjl test
   coverage_script:
     - cirrusjl coverage codecov coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ julia:
   - nightly
 matrix:
   allow_failures:
+  - arch: arm64
   - julia: nightly
+  - os: windows
 notifications:
   email: false
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - arm64
 language: julia
 julia:
   - 1.3
@@ -10,6 +13,7 @@ notifications:
 os:
   - linux
   - osx
+  - windows
 dist: bionic
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ notifications:
 os:
   - linux
   - osx
-dist: trusty
-sudo: false
-addons:
-  apt:
-    packages:
-    - xorg-dev
-before_script:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start; fi
+dist: bionic
+services:
+  - xvfb

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using GLFW, Test
 
-print(GLFW.GetVersionString())
+println(GLFW.GetVersionString())
 
 # GLFWError uses enum for known error code
 @test isa(GLFW.GLFWError(GLFW.NOT_INITIALIZED, "").code, GLFW.ErrorCode)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using GLFW, Test
 
+print(GLFW.GetVersionString())
+
 # GLFWError uses enum for known error code
 @test isa(GLFW.GLFWError(GLFW.NOT_INITIALIZED, "").code, GLFW.ErrorCode)
 @test GLFW.GLFWError(0x00010001, "").code == GLFW.NOT_INITIALIZED


### PR DESCRIPTION
- Simplify Travis config by using `xvfb` service.
- Enable Arm64 and Windows on Travis, but allow failures since they're flaky.
  - Once they're working, AppVeyor and Drone CI can be replaced.
- Allow Cirrus CI failures since it needs `xvfb` setup.