### PR TITLE
[BUGFIX] Use actions instead of bools for GetKey and GetMouseButton

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -605,8 +605,8 @@ function GetKeyName(key, scancode=0)
 	end
 end
 
-GetKey(window::Window, key) = Bool(ccall((:glfwGetKey, libglfw), Cint, (Window, Cint), window, key))
-GetMouseButton(window::Window, button::MouseButton) = Bool(ccall((:glfwGetMouseButton, libglfw), Cint, (Window, Cint), window, button))
+GetKey(window::Window, key) = ccall((:glfwGetKey, libglfw), Action, (Window, Cint), window, key)
+GetMouseButton(window::Window, button::MouseButton) = ccall((:glfwGetMouseButton, libglfw), Action, (Window, Cint), window, button)
 
 function GetCursorPos(window::Window)
 	x, y = Ref{Cdouble}(), Ref{Cdouble}()


### PR DESCRIPTION
@SimonDanisch 

According to [the docs](https://www.glfw.org/docs/3.3/group__input.html#gadd341da06bc8d418b4dc3a3518af9ad2) those two function should return an enum with 3 possible states (Press, Release, Repeat).

Previous wrapped behaviour is wrong.

While this is a bugfix, I can understand that it is technically breaking so I should bump the minor version to 3.4.0?