### PR TITLE
relax type constraint of GetMouseButton

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -641,7 +641,7 @@ function GetKeyName(key, scancode=0)
 end
 
 GetKey(window::Window, key) = Bool(ccall((:glfwGetKey, libglfw), Cint, (Window, Cint), window, key))
-GetMouseButton(window::Window, button::MouseButton) = Bool(ccall((:glfwGetMouseButton, libglfw), Cint, (Window, Cint), window, button))
+GetMouseButton(window::Window, button) = Bool(ccall((:glfwGetMouseButton, libglfw), Cint, (Window, Cint), window, button))
 
 function GetCursorPos(window::Window)
 	x, y = Ref{Cdouble}(), Ref{Cdouble}()


### PR DESCRIPTION
This allows you to use `GLFW.GetMouseButton(window, Cint(...))`. 