### PR TITLE
Make `GetKey(win, KEY_ESCAPE) == PRESS` work

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -8,6 +8,15 @@
 	PRESS                  = 1
 	REPEAT                 = 2
 end
+# GetKey is defined below to return a Bool, but in the documentation it is
+# defined as returning PRESS or RELEASE. In C that doesn't matter, but in
+# Julia these are different types and so e.g.
+# `GLFW.GetKey(window, GLFW.KEY_ESCAPE)) == GLFW.PRESS` will always return
+# false.
+#
+# This method tells Julia how to compare an Action and a Bool so that code
+# calling GetKey as documented will work as expected.
+Base.(==)(b::Bool, a::Action) = b == Integer(a)
 
 @enum Key::Cint begin
 	# Unknown key

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ println(GLFW.GetVersionString())
 # GLFWError uses integer for unrecognized error code
 @test isa(GLFW.GLFWError(0xDEADBEEF, "").code, Integer)
 
+# https://github.com/JuliaGL/GLFW.jl/pull/225
+@test GLFW.PRESS == true
+@test GLFW.RELEASE == false
+
 if !haskey(ENV, "CI")  # AppVeyor and Travis CI don't support OpenGL
 	include("windowclose.jl")
 end


### PR DESCRIPTION
`GetKey` is defined to return a `Bool`

https://github.com/JuliaGL/GLFW.jl/blob/e8d581549ef891485a3ede6c8cac0611de742d3e/src/glfw3.jl#L648

, but in the [documentation](https://www.glfw.org/docs/latest/group__input.html#gadd341da06bc8d418b4dc3a3518af9ad2) it is defined as returning `PRESS` or `RELEASE`. In C that doesn't matter because true, false PRESS and RELEASE are all integers and RELEASE is equal to false. But in Julia these are different types and so e.g. `GLFW.GetKey(window, GLFW.KEY_ESCAPE)) == GLFW.PRESS` will always return false.

This breaks the example in the Readme of GLAbstraction.jl:

```jl
    if GLFW.GetKey(window, GLFW.KEY_ESCAPE) == GLFW.PRESS
        GLFW.SetWindowShouldClose(window, true)
    end
```

The method added in this PR tells Julia how to compare an `Action` and a `Bool` so that code calling `GetKey` as documented will work as expected, while also not breaking existing code that expects GetKey to return a `Bool` (e.g. the code in #163).

Julia will do slightly more work when comparing `Bool` and `Action` than when comparing two `Bool`s because it will expand the Bool to 32 bits first. This could be avoided by defining the basetype of the `Action` enum as `UInt8`, but that would be a breaking change if arrays of `Action` are ever passed to C (I don't think they would be, but idk).

I tried to persuade Julia to omit the expansion to 32 bits, but I couldn't find anything that worked. Closest was `b == unsafe_trunc(Bool, a)`, but that still emits more instructions than comparing two `Bool`s.