### PR TITLE
Fix #225

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -16,7 +16,8 @@ end
 #
 # This method tells Julia how to compare an Action and a Bool so that code
 # calling GetKey as documented will work as expected.
-Base.(==)(b::Bool, a::Action) = b == Integer(a)
+Base.:(==)(b::Bool, a::Action) = b == Integer(a)
+Base.:(==)(a::Action, b::Bool) = b == a
 
 @enum Key::Cint begin
 	# Unknown key

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,9 @@ println(GLFW.GetVersionString())
 
 # https://github.com/JuliaGL/GLFW.jl/pull/225
 @test GLFW.PRESS == true
+@test true == GLFW.PRESS
 @test GLFW.RELEASE == false
+@test false == GLFW.RELEASE
 
 if !haskey(ENV, "CI")  # AppVeyor and Travis CI don't support OpenGL
 	include("windowclose.jl")


### PR DESCRIPTION
This is embarrassing, I managed to commit a typo in my last pull request (I left out a colon) and that breaks the package.

This commit also ensures that ==(Action, Bool) gives the same result as ==(Bool, Action), because that just makes sense.

Sorry, Simon!