### PR TITLE
Remove callbacks from window user pointer

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -604,6 +604,9 @@ function WindowHintString(hint::Integer, value::AbstractString)
 	ccall((:glfwWindowHintString, libglfw), Cvoid, (Cint, Cstring), hint, value)
 end
 
+GetWindowUserPointer(window::Window) = ccall((:glfwGetWindowUserPointer, libglfw), Ptr{Cvoid}, (Window,), window)
+SetWindowUserPointer(window::Window, ptr::Ptr{Cvoid}) = ccall((:glfwSetWindowUserPointer, libglfw), Cvoid, (Window, Ptr{Cvoid}), window, ptr)
+
 RequestWindowAttention(window::Window) = ccall((:glfwRequestWindowAttention, libglfw), Cvoid, (Window,), window)
 
 GetWindowOpacity(window::Window) = ccall((:glfwGetWindowOpacity, libglfw), Cfloat, (Window,), window)


### PR DESCRIPTION
Assuming the window user pointer can be used for callbacks goes beyond what an 'interface' should do, imo. GLFW.jl and CImGui.jl's GLFW backend can't be used together because of this problem, for instance.

see #206 and #220