### PR TITLE
Ignore SetWindowIcon calls on MacOS

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -538,6 +538,8 @@ Set the window icon, where a single image may be passed or a vector of images wi
 The images must be of RGBA format. Before calling this function it might be necessary to reinterpret the image
 as a matrix of element type NTuple{4, UInt8}  if the icons are loaded with type RGBA{N0f8}
 
+Note that this is implemented as a no-op on MacOS since that platform does not have the concept of a window icon.
+
 # Examples
 ```julia-repl
 using FileIO
@@ -550,11 +552,15 @@ GLFW.PollEvents() # needs a poll events to become active
 SetWindowIcon
 
 function SetWindowIcon(window::Window, images::Vector{<:AbstractMatrix{NTuple{4,UInt8}}})
-	ccall((:glfwSetWindowIcon, libglfw), Cvoid, (Window, Cint, Ref{GLFWImage}), window, length(images), images)
+	if !Sys.isapple()
+		ccall((:glfwSetWindowIcon, libglfw), Cvoid, (Window, Cint, Ref{GLFWImage}), window, length(images), images)
+	end
 end
 
 function SetWindowIcon(window::Window, image::AbstractMatrix{NTuple{4,UInt8}})
-	ccall((:glfwSetWindowIcon, libglfw), Cvoid, (Window, Cint, Ref{GLFWImage}), window, 1, image)
+	if !Sys.isapple()
+		ccall((:glfwSetWindowIcon, libglfw), Cvoid, (Window, Cint, Ref{GLFWImage}), window, 1, image)
+	end
 end
 
 function GetWindowPos(window::Window)

--- a/test/windowclose.jl
+++ b/test/windowclose.jl
@@ -1,12 +1,23 @@
 using GLFW, Test
 
-window = GLFW.CreateWindow(800, 600, "InexactError")
-@test !GLFW.WindowShouldClose(window)
-# If you call the julia function GLFW.SetWindowShouldClose(window,
-# truefalse), then only 0 or 1 can be passed. However, at least on
-# some platforms (Linux), clicking on the window's close icon can send
-# other values (like 189). Make sure such values don't cause trouble for
-# GLFW.WindowShouldClose.
-ccall((:glfwSetWindowShouldClose, GLFW.libglfw), Cvoid, (GLFW.Window, Cint), window, 189)
-@test GLFW.WindowShouldClose(window)
-GLFW.DestroyWindow(window)
+@testset "WindowShouldClose" begin
+    window = GLFW.CreateWindow(800, 600, "InexactError")
+    @test !GLFW.WindowShouldClose(window)
+    # If you call the julia function GLFW.SetWindowShouldClose(window,
+    # truefalse), then only 0 or 1 can be passed. However, at least on
+    # some platforms (Linux), clicking on the window's close icon can send
+    # other values (like 189). Make sure such values don't cause trouble for
+    # GLFW.WindowShouldClose.
+    ccall((:glfwSetWindowShouldClose, GLFW.libglfw), Cvoid, (GLFW.Window, Cint), window, 189)
+    @test GLFW.WindowShouldClose(window)
+    GLFW.DestroyWindow(window)
+end
+
+@testset "SetWindowIcon" begin
+    window = GLFW.CreateWindow(800, 600, "InexactError")
+    icon = reshape([repeat([(0x00, 0x00, 0x00, 0x00)], 128 * 128)...], (128,128))
+    # 2 methods, test both:
+    GLFW.SetWindowIcon(window, icon)
+    GLFW.SetWindowIcon(window, [icon])
+    GLFW.DestroyWindow(window)
+end


### PR DESCRIPTION
This should effectively fix https://github.com/MakieOrg/Makie.jl/issues/3997 for users of Makie 0.20 without a new release of that package.