### PR TITLE
Add new `InitHint` API and constants & use on Linux to prefer X11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "3.4.2"
 GLFW_jll = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
 
 [compat]
-GLFW_jll = "3.3.3"
+GLFW_jll = "3.4"
 julia = "1.3.0"
 
 [extras]


### PR DESCRIPTION
The Wayland backend doesn't seem to work well yet (presumably related to how the underlying JLLs are compiled/assembled), so preferring the X11 backend side-steps the issue for now.

For me fixes the same error as reported in https://discourse.julialang.org/t/installing-glmakie-on-linux-fails/116468

Related: MakieOrg/Makie.jl#4002