### PR TITLE
Enable Wayland on Linux if available

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -496,16 +496,8 @@ is_initialized() = INITIALIZED[]
 # Initialization and version information
 InitHint(hint, value) = @require_main_thread ccall((:glfwInitHint, libglfw), Cvoid, (Cint, Cint), hint, value)
 
-function Init()
+function Init(; platform::Platform = ANY_PLATFORM)
 	require_main_thread()
-	platform::Platform = ANY_PLATFORM
-	if Sys.islinux()
-		if haskey(ENV, "XDG_SESSION_TYPE")
-			platform = ENV["XDG_SESSION_TYPE"] == "wayland" ? PLATFORM_WAYLAND : PLATFORM_X11
-		else
-			platform = PLATFORM_X11
-		end
-	end
 	InitHint(PLATFORM, platform)
 	INITIALIZED[] = Bool(ccall((:glfwInit, libglfw), Cint, ())) || error("glfwInit failed")
 end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -496,9 +496,12 @@ is_initialized() = INITIALIZED[]
 # Initialization and version information
 InitHint(hint, value) = @require_main_thread ccall((:glfwInitHint, libglfw), Cvoid, (Cint, Cint), hint, value)
 
-function Init(; platform::Platform = @static Sys.islinux() ? PLATFORM_X11 : ANY_PLATFORM)
+function Init()
 	require_main_thread()
-	# TODO: Resolve why trying Wayland backend causes errors
+	platform::Platform = ANY_PLATFORM
+	if Sys.islinux()
+		platform = ENV["XDG_SESSION_TYPE"] == "wayland" ? PLATFORM_WAYLAND : PLATFORM_X11
+	end
 	InitHint(PLATFORM, platform)
 	INITIALIZED[] = Bool(ccall((:glfwInit, libglfw), Cint, ())) || error("glfwInit failed")
 end

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -500,7 +500,11 @@ function Init()
 	require_main_thread()
 	platform::Platform = ANY_PLATFORM
 	if Sys.islinux()
-		platform = ENV["XDG_SESSION_TYPE"] == "wayland" ? PLATFORM_WAYLAND : PLATFORM_X11
+		if haskey(ENV, "XDG_SESSION_TYPE")
+			platform = ENV["XDG_SESSION_TYPE"] == "wayland" ? PLATFORM_WAYLAND : PLATFORM_X11
+		else
+			platform = PLATFORM_X11
+		end
 	end
 	InitHint(PLATFORM, platform)
 	INITIALIZED[] = Bool(ccall((:glfwInit, libglfw), Cint, ())) || error("glfwInit failed")


### PR DESCRIPTION
~~Replace previous platform hint selection logic to account for Wayland platforms, while still falling back to X11 when Wayland is not available. Relies on XDG_SESSION_TYPE environment variable.~~

Make the default platform `ANY_PLATFORM`, which will use Wayland when possible. Works with Sway, Hyprland, KWin, and Mutter. Also lightly tested GLMakie by plotting a couple of lines with this change and it worked as expected. ~~It might be worth noting that GLMakie fails to compile on COSMIC with this change, but GLFW.jl directly still works fine.~~

By functioning GLFW.jl I mean the README example:

```
using GLFW

# Create a window and its OpenGL context
window = GLFW.CreateWindow(640, 480, "GLFW.jl")

# Make the window's context current
GLFW.MakeContextCurrent(window)

# Loop until the user closes the window
while !GLFW.WindowShouldClose(window)

	# Render here

	# Swap front and back buffers
	GLFW.SwapBuffers(window)

	# Poll for and process events
	GLFW.PollEvents()
end

GLFW.DestroyWindow(window)
```

Issues:

- [x] xkbcommon warning: `xkbcommon: ERROR: couldn't find a Compose file for locale "en_US.UTF-8" (mapped to "en_US.UTF-8")`
    * Julia looks for ~/.XCompose. The warning can be worked around with `ln -s /usr/share/X11/locale/en_US.UTF-8/Compose ~/.XCompose`
- [ ] Window icons don't show. (https://github.com/glfw/glfw/pull/2686)

Should fix #188 
More testing appreciated. Thanks!