### PR TITLE
Allow GLFW platform selection from environment variables

### DIFF
--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -498,9 +498,29 @@ InitHint(hint, value) = @require_main_thread ccall((:glfwInitHint, libglfw), Cvo
 
 function Init(; platform::Platform = @static Sys.islinux() ? PLATFORM_X11 : ANY_PLATFORM)
 	require_main_thread()
-	# TODO: Resolve why trying Wayland backend causes errors
+	if haskey(ENV, "JULIA_GLFW_PLATFORM")
+		platform = HandlePlatformSelection()
+	end
 	InitHint(PLATFORM, platform)
 	INITIALIZED[] = Bool(ccall((:glfwInit, libglfw), Cint, ())) || error("glfwInit failed")
+end
+
+function HandlePlatformSelection()::Platform
+	platform::String = ENV["JULIA_GLFW_PLATFORM"]
+
+	if platform == "PLATFORM_WIN32"
+		return PLATFORM_WIN32
+	elseif platform == "PLATFORM_COCOA"
+		return PLATFORM_COCOA
+	elseif platform == "PLATFORM_WAYLAND"
+		return PLATFORM_WAYLAND
+	elseif platform == "PLATFORM_X11"
+		return PLATFORM_X11
+	elseif platform == "PLATFORM_NULL"
+		return PLATFORM_NULL
+	else
+		return ANY_PLATFORM
+	end
 end
 
 function Terminate()

--- a/src/glfw3.jl
+++ b/src/glfw3.jl
@@ -508,15 +508,15 @@ end
 function HandlePlatformSelection()::Platform
 	platform::String = ENV["JULIA_GLFW_PLATFORM"]
 
-	if platform == "PLATFORM_WIN32"
+	if platform == "win32"
 		return PLATFORM_WIN32
-	elseif platform == "PLATFORM_COCOA"
+	elseif platform == "cocoa"
 		return PLATFORM_COCOA
-	elseif platform == "PLATFORM_WAYLAND"
+	elseif platform == "wayland"
 		return PLATFORM_WAYLAND
-	elseif platform == "PLATFORM_X11"
+	elseif platform == "x11"
 		return PLATFORM_X11
-	elseif platform == "PLATFORM_NULL"
+	elseif platform == "null"
 		return PLATFORM_NULL
 	else
 		return ANY_PLATFORM


### PR DESCRIPTION
Should be easier to merge than https://github.com/JuliaGL/GLFW.jl/pull/244 since functionality will be the same as before unless specified by the `JULIA_GLFW_PLATFORM` environment variable.